### PR TITLE
Limit gamepak_size to 0x1FFFF00 (taken from TempGBA)

### DIFF
--- a/gba_memory.c
+++ b/gba_memory.c
@@ -482,6 +482,13 @@ void function_cc write_eeprom(u32 unused_address, u32 value)
 {
   if (backup_type == BACKUP_DISABLED)
     return;
+  
+  // ROM is restricted to 8000000h-9FFFeFFh
+  // (max.1FFFF00h bytes = 32MB minus 256 bytes)
+  if (gamepak_size > 0x1FFFF00)
+  {
+    gamepak_size = 0x1FFFF00;
+  }
 
   switch(eeprom_mode)
   {


### PR DESCRIPTION
This needs a bit of understanding/rationalising before committing.

Found this whilst troubleshooting why my local dev copy recognises Yggdra Union saves both on startup and within save states, but all other versions do not!

By process of elimination, found these lines that I had added previously whilst going through TempGBA code.  Turns out that adding them to the latest commit fixes all the saving in Yggdra Union (override no longer required).  Perhaps this fixes other 32MB games that use EEPROM also?